### PR TITLE
Fix: Critical bugs in send_what_msg

### DIFF
--- a/whatpack/synchronous/whats.py
+++ b/whatpack/synchronous/whats.py
@@ -99,14 +99,14 @@ def send_what_msg(
         "%H:%M:%S",
     )
 
-    if left_time.seconds < time_['wait_time']:
+    if left_time.seconds < waiting_['wait_time']:
         raise exceptions.CallTimeException(
             "Call Time must be Greater than Wait Time as WhatsApp Web takes some Time to Load!"
         )
 
     sleep_time = left_time.seconds - waiting_['wait_time']
     print(
-        f"In {waiting_['sleep_time']} Seconds WhatsApp will open and after\
+        f"In {sleep_time} Seconds WhatsApp will open and after\
         {waiting_['wait_time']} Seconds Message will be Delivered!"
     )
     time.sleep(sleep_time)


### PR DESCRIPTION
These were some errors I encountered while using the library. The wrong dict was used to fetch the 'wait_time' key and the 'sleep_time' variable was incorrectly used, which I've fixed.

cc: @SigireddyBalasai 